### PR TITLE
Pea/add dockerfile db plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM wordpress:latest
+
+# Add sudo in order to run wp-cli as the www-data user
+RUN apt-get update && apt-get install -y sudo less vim unzip git
+
+# Add WP-CLI
+RUN curl -o /bin/wp-cli.phar https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
+COPY wp-su.sh /bin/wp
+RUN chmod +x /bin/wp-cli.phar /bin/wp
+
+# Add PHP Composer
+RUN curl -sS https://getcomposer.org/installer -o composer-setup.php
+RUN php composer-setup.php --install-dir=/usr/local/bin --filename=composer
+RUN composer self-update

--- a/auth.json.example
+++ b/auth.json.example
@@ -1,0 +1,8 @@
+{
+    "http-basic": {
+      "composer.deliciousbrains.com": {
+        "username": "{COMPOSER_API_USERNAME}",
+        "password": "{COMPOSER_API_PASSWORD}"
+      }
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,10 @@
             ]
         },
         {
+            "type":"composer",
+            "url":"https://composer.deliciousbrains.com"
+        },
+        {
             "type": "package",
             "package": {
               "name": "advanced-custom-fields/advanced-custom-fields-pro",
@@ -81,6 +85,7 @@
         "wpackagist-plugin/headless-mode":"^0.4.0",
         "wpackagist-plugin/edit-flow":"^0.9.7",
         "wpackagist-plugin/co-authors-plus":"^3.5.15",
+        "deliciousbrains-plugin/wp-migrate-db-pro": "*",
         "vlucas/phpdotenv": "^5.4.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b4efbfd46bd6291101120cc3803f8a3a",
+    "content-hash": "110fcf3380412cbe74ad780c95a31525",
     "packages": [
         {
             "name": "advanced-custom-fields/advanced-custom-fields-pro",
@@ -169,6 +169,30 @@
                 }
             ],
             "time": "2021-09-13T08:19:44+00:00"
+        },
+        {
+            "name": "deliciousbrains-plugin/wp-migrate-db-pro",
+            "version": "2.6.10",
+            "dist": {
+                "type": "zip",
+                "url": "https://composer.deliciousbrains.com/?wc-api=delicious-brains&request=composer_download&package=wp-migrate-db-pro&version=2.6.10"
+            },
+            "require": {
+                "composer/installers": "~1.0 || ~2.0"
+            },
+            "type": "wordpress-plugin"
+        },
+        {
+            "name": "deliciousbrains-plugin/wp-migrate-db-pro-cli",
+            "version": "1.6.0",
+            "dist": {
+                "type": "zip",
+                "url": "https://composer.deliciousbrains.com/?wc-api=delicious-brains&request=composer_download&package=wp-migrate-db-pro-cli&version=1.6.0"
+            },
+            "require": {
+                "composer/installers": "~1.0 || ~2.0"
+            },
+            "type": "wordpress-plugin"
         },
         {
             "name": "ffraenz/private-composer-installer",
@@ -736,15 +760,15 @@
         },
         {
             "name": "wpackagist-plugin/block-visibility",
-            "version": "3.0.4",
+            "version": "3.1.1",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/block-visibility/",
-                "reference": "tags/3.0.4"
+                "reference": "tags/3.1.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/block-visibility.3.0.4.zip"
+                "url": "https://downloads.wordpress.org/plugin/block-visibility.3.1.1.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"


### PR DESCRIPTION
- [Add WP Migrate DB Pro plugin to `composer.json`](https://github.com/misfist/bookforum-dependencies/pull/1/commits/fa988ed0617ee34882db693a6c310443290f5835)
- [Add example `auth.json` file for WP Migrate DB Pro authentication](https://github.com/misfist/bookforum-dependencies/pull/1/commits/ed76da34ca5fb245788dfc3ddf6e9c77d40861ae)
- [Add example `Dockerfile`](https://github.com/misfist/bookforum-dependencies/pull/1/commits/22e57f0acfb0374c5cdc5278303dd303832367e6)
   - Adds example for installing WP-CLI and Composer